### PR TITLE
The linter f**ked everything without me noticing

### DIFF
--- a/src/Base/Interval.hs
+++ b/src/Base/Interval.hs
@@ -146,7 +146,7 @@ jumpIntervalFromNote :: Interval -> Root -> Root
 jumpIntervalFromNote (Interval iQual iNum) r =
   let
     newNote    = nextNthNote (getRoot r) $ iNum - 1
-    currDist   = getPitchClass (rootToPitchClass $ rootFrom newNote natural)
+    currDist   = getPitchClass (rootToPitchClass (rootFrom newNote natural)) - getPitchClass (rootToPitchClass r)
     wantedDist =
       case intervalToDistance $ Interval iQual iNum of
         Just dist -> dist


### PR DESCRIPTION
My Haskell linter was _way_ too aggressive at one point in the recent past, and deleted some meaningful code. I've fixed it, and manually applied the linter suggestions.