### PR TITLE
Scales and Modes

### DIFF
--- a/src/Base/Core/Accidental.hs
+++ b/src/Base/Core/Accidental.hs
@@ -4,12 +4,14 @@ module Base.Core.Accidental
   , nFlats
   , natural
   , impliedShift
+  , shiftToAcc
   ) where
 
 data Accidental
  = AccSharp Int
  | AccFlat Int
  | AccNatural
+ deriving Eq
 
 instance Show Accidental where
   show (AccSharp i) = concat $ replicate i "#"
@@ -29,3 +31,10 @@ impliedShift :: Accidental -> Int
 impliedShift (AccSharp i) = i
 impliedShift (AccFlat i)  = -i
 impliedShift AccNatural   = 0
+
+shiftToAcc :: Int -> Accidental
+shiftToAcc i = 
+  case signum i of
+        1  -> nSharps i
+        -1 -> nFlats (-i)
+        0  -> natural

--- a/src/Base/Core/Accidental.hs
+++ b/src/Base/Core/Accidental.hs
@@ -34,7 +34,6 @@ impliedShift AccNatural   = 0
 
 shiftToAcc :: Int -> Accidental
 shiftToAcc i = 
-  case signum i of
-        1  -> nSharps i
-        -1 -> nFlats (-i)
-        0  -> natural
+  | i > 0     = AccSharp i
+  | i < 0     = AccFlat (-i)
+  | otherwise = AccNatural

--- a/src/Base/Interval.hs
+++ b/src/Base/Interval.hs
@@ -151,10 +151,5 @@ jumpIntervalFromNote (Interval iQual iNum) r =
       case intervalToDistance $ Interval iQual iNum of
         Just dist -> dist
         Nothing -> error "Invalid interval in jumpIntervalFromNote"
-    diff   = lowestAbsValue $ wantedDist - currDist
-    newAcc =
-      case signum diff of
-        1  -> nSharps diff
-        -1 -> nFlats (-diff)
-        0  -> natural
+    newAcc     = shiftToAcc $ lowestAbsValue $ wantedDist - currDist  
   in rootFrom newNote newAcc

--- a/src/Base/Interval.hs
+++ b/src/Base/Interval.hs
@@ -9,6 +9,7 @@ module Base.Interval
   , jumpIntervalFromNote
   , (|+|)
   , (|-|)
+  , invert
   ) where
 
 import Base.Core.Accidental

--- a/src/Language/Parser.hs
+++ b/src/Language/Parser.hs
@@ -122,7 +122,7 @@ parserChord :: Parser Chord
 parserChord =
   do root <- parserRoot
      mqual <- optionMaybe parserQuality
-     highestQual <- option (majorNatural 5) parserHighestNatural
+     highestQual <- option (nonMajorNatural 5) parserHighestNatural
      exts <- many parserExtension
      sus <- parserSus
      eof

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -22,7 +22,7 @@ import Base.Interval as I
     , jumpIntervalFromNote
     , intervalToDistance
     )
-import Scale (Scale(..), scaleToIntervals)
+import Scale (Scale(..), BaseMode(..), baseModeIntervals)
 import Data.Set(Set(..))
 import qualified Data.Set as S
 import Data.Map.Strict (Map, insert, fromList, toList, (!), delete, (!?))
@@ -47,14 +47,14 @@ type HeliotonicScale = Map Int Interval
 
 
 qualityToIntervals :: CQ.Quality -> HeliotonicScale
-qualityToIntervals qual = fromList $ zip [1..7] $ scaleToIntervals $ qualityToScale qual
+qualityToIntervals qual = fromList $ zip [1..7] $ S.toList $ baseModeIntervals $ qualityToScale qual
   where
-    qualityToScale :: CQ.Quality -> Scale
-    qualityToScale CQ.Major = SLydian
-    qualityToScale CQ.Minor = SDorian
-    qualityToScale CQ.Dominant = SMixolydian
-    qualityToScale CQ.Augmented = SAugmentedQuality
-    qualityToScale CQ.Diminished = SDiminishedQuality
+    qualityToScale :: CQ.Quality -> BaseMode
+    qualityToScale CQ.Major = Lydian
+    qualityToScale CQ.Minor = Dorian
+    qualityToScale CQ.Dominant = Mixolydian
+    qualityToScale CQ.Augmented = AugmentedQuality
+    qualityToScale CQ.Diminished = DiminishedQuality
 
 
 susIntervals :: HeliotonicScale -> Sus -> HeliotonicScale

--- a/src/Scale.hs
+++ b/src/Scale.hs
@@ -74,7 +74,7 @@ data BaseMode
 
 
 nthDegreeIntervals :: Set Interval -> Int -> Set Interval
-nthDegreeIntervals ints n = fromList $ (|-| rootInterval) <$> toAscList ints
+nthDegreeIntervals ints n = S.map (|-| rootInterval) ints
   where
     rootInterval = toAscList ints !! (n - 1)
 

--- a/src/Scale.hs
+++ b/src/Scale.hs
@@ -31,11 +31,17 @@ import Data.Function
 
 data Scale = Scale Root Mode
 
+instance Show Scale where
+  show (Scale root mode) = show root ++ show mode
 
 data Mode = Mode BaseMode [ScaleExt]
 
 instance Show Mode where
-  show (Mode base exts) = show base ++ " " ++ (intercalate ", " (show <$> exts))
+  show (Mode base exts) = show base
+                       --Add a space if there are extensions...
+                       ++ (replicate (signum (length (exts))) ' ')
+                       --Add extensions separated by a comma...
+                       ++ (intercalate ", " (show <$> exts))        
 
 data ScaleExt = ScaleExt { acc :: Accidental
                          , deg :: Int

--- a/src/Scale.hs
+++ b/src/Scale.hs
@@ -39,7 +39,7 @@ data Mode = Mode BaseMode [ScaleExt]
 instance Show Mode where
   show (Mode base exts) = show base
                        --Add a space if there are extensions...
-                       ++ (replicate (signum (length (exts))) ' ')
+                       ++ if null exts then "" else " "
                        --Add extensions separated by a comma...
                        ++ (intercalate ", " (show <$> exts))        
 

--- a/src/Scale.hs
+++ b/src/Scale.hs
@@ -177,7 +177,7 @@ intervalsToMode intSet =
     distanceFromIntSet :: Set Interval -> BaseMode -> Int
     distanceFromIntSet iSet mode = modalDistance iSet $ baseModeIntervals mode
     sortedModes = sortBy (compare `on` distanceFromIntSet intSet) sameDegreeModes
-    exts = modesToExts intSet <$> (baseModeIntervals <$> sortedModes)
+    exts = modesToExts intSet . baseModeIntervals <$> sortedModes
   in
     takeWhile (\mode -> numAlteredDegsInMode mode == minimum (length <$> exts)) $ (\(x,y) -> Mode x y) <$> zip sortedModes exts
 

--- a/src/Scale.hs
+++ b/src/Scale.hs
@@ -146,7 +146,7 @@ scaleToNotes (Scale root mode) = mapMonotonic (`jumpIntervalFromNote` root) (mod
 
 
 modalDistance :: Set Interval -> Set Interval -> Int
-modalDistance mode1 mode2 = sum $ intDistance <$> zip (toAscList mode1) (toAscList mode2)
+modalDistance mode1 mode2 = sum $ intDistance <$> (zip `on` toAscList) mode1 mode2
   where 
     intDistance :: (Interval, Interval) -> Int
     intDistance (i1, i2) = abs $ fromJust $ intervalToDistance (i1 |-| i2) 

--- a/src/Scale.hs
+++ b/src/Scale.hs
@@ -142,7 +142,7 @@ modeToIntervals (Mode baseMode exts) = foldr extIntervals (baseModeIntervals bas
 
 
 scaleToNotes :: Scale -> Set Root
-scaleToNotes (Scale root mode) = mapMonotonic (flip jumpIntervalFromNote root) (modeToIntervals mode)
+scaleToNotes (Scale root mode) = mapMonotonic (`jumpIntervalFromNote` root) (modeToIntervals mode)
 
 
 modalDistance :: Set Interval -> Set Interval -> Int

--- a/src/Scale.hs
+++ b/src/Scale.hs
@@ -159,13 +159,9 @@ modesToExts mode1 mode2 =
     intervalDiffToAcc :: Interval -> Interval -> Accidental
     intervalDiffToAcc i1 i2 = shiftToAcc $ fromJust $ intervalToDistance $ i2 |-| i1
     accToExtList :: Accidental -> Int -> [ScaleExt] -> [ScaleExt]
-    accToExtList accidental degree = 
-      if accidental == natural then
-        id
-      else  
-        (++ [ScaleExt { acc = accidental
-                      , deg = degree 
-                      }])
+    accToExtList accidental degree
+      | accidental == natural = id
+      | otherwise             = (ScaleExt { acc = accidental, deg = degree } :)
   in  
     foldr (\(i1,i2) exts -> accToExtList (intervalDiffToAcc i2 i1) (getSize i1) exts) 
           []

--- a/src/Scale.hs
+++ b/src/Scale.hs
@@ -1,99 +1,109 @@
 module Scale
   ( Scale(..)
-  , scaleToIntervals
+  , BaseMode(..)
+  , baseModeIntervals
   ) where
 
 import Base.Core.Quality.IQuality
-
+import Base.Chord.Root
+import Base.Chord.Extension
 import Base.Interval (Interval, intervalFrom, (|+|), (|-|))
+import Base.Core.Accidental
 import Data.List (sort)
+import Data.Set(Set(..), fromList, toAscList)
 
 
-data Scale
-  = SLydian
-  | SDorian
-  | SMixolydian
-  | SAugmentedQuality
-  | SDiminishedQuality
-  | SMajor
-  | SMinor
-  | SPhrygian
-  | SLocrian
-  | SMelodicMinor
-  | SDorianb2
-  | SLydianAug
-  | SLydianDom
-  | SMixolydianb6
-  | SLocrianSharp2
-  | SAltered
-  | SHarmonicMinor
-  | SLocrianNat6
-  | SIonianSharp5
-  | SDorianSharp4
-  | SPhrygianDom
-  | SLydianSharp2
-  | SSuperLocrianbb7
+data Scale = Root Mode
 
 
-nthDegreeIntervals :: [Interval] -> Int -> [Interval]
-nthDegreeIntervals ints n = sort $ (|-| rootInterval) <$> ints
+data Mode = BaseMode [ScaleExt]
+
+
+data ScaleExt = Accidental Int
+
+
+data BaseMode 
+  = Lydian
+  | Dorian
+  | Mixolydian
+  | AugmentedQuality
+  | DiminishedQuality
+  | Ionian
+  | Aeolian
+  | Phrygian
+  | Locrian
+  | MelodicMinor
+  | LydianAug
+  | LydianDom
+  | Altered
+  | HarmonicMinor
+  | PhrygianDom
+  | DoubleHarmonicMinor
+  | HarmonicMajor
+  | DoubleHarmonicMajor
+  deriving Show
+
+nthDegreeIntervals :: Set Interval -> Int -> Set Interval
+nthDegreeIntervals ints n = fromList $ (|-| rootInterval) <$> toAscList ints
   where
-    rootInterval = ints !! (n - 1)
+    rootInterval = toAscList ints !! (n - 1)
 
 
-listIntervals :: [Quality] -> [Int] -> [Interval]
-listIntervals qualities ints = uncurry intervalFrom <$> zip qualities ints
+zipToIntervalSet :: [Quality] -> [Int] -> Set Interval
+zipToIntervalSet qualities ints = fromList $ uncurry intervalFrom <$> zip qualities ints
 
 
-scaleToIntervals :: Scale -> [Interval]
-scaleToIntervals SMajor =
-  listIntervals
+baseModeIntervals :: BaseMode -> Set Interval
+baseModeIntervals Ionian =
+  zipToIntervalSet
   [Perfect, Major, Major, Perfect, Perfect, Major, Major] [1..7]
-scaleToIntervals SDorian =
-  nthDegreeIntervals (scaleToIntervals SMajor) 2
-scaleToIntervals SPhrygian =
-  nthDegreeIntervals (scaleToIntervals SMajor) 3
-scaleToIntervals SLydian =
-  nthDegreeIntervals (scaleToIntervals SMajor) 4
-scaleToIntervals SMixolydian =
-  nthDegreeIntervals (scaleToIntervals SMajor) 5
-scaleToIntervals SMinor =
-  nthDegreeIntervals (scaleToIntervals SMajor) 6
-scaleToIntervals SLocrian =
-  nthDegreeIntervals (scaleToIntervals SMajor) 7
-scaleToIntervals SAugmentedQuality =
-  listIntervals
+baseModeIntervals Dorian =
+  nthDegreeIntervals (baseModeIntervals Ionian) 2
+baseModeIntervals Phrygian =
+  nthDegreeIntervals (baseModeIntervals Ionian) 3
+baseModeIntervals Lydian =
+  nthDegreeIntervals (baseModeIntervals Ionian) 4
+baseModeIntervals Mixolydian =
+  nthDegreeIntervals (baseModeIntervals Ionian) 5
+baseModeIntervals Aeolian =
+  nthDegreeIntervals (baseModeIntervals Ionian) 6
+baseModeIntervals Locrian =
+  nthDegreeIntervals (baseModeIntervals Ionian) 7
+baseModeIntervals AugmentedQuality =
+  zipToIntervalSet
   [Perfect, Major, Major, Augmented 1, Augmented 1, Major, Minor] [1..7]
-scaleToIntervals SDiminishedQuality =
-  listIntervals
+baseModeIntervals DiminishedQuality =
+  zipToIntervalSet
   [Perfect, Major, Minor, Perfect, Diminished 1, Minor, Diminished 1] [1..7]
-scaleToIntervals SMelodicMinor =
-  listIntervals
+baseModeIntervals MelodicMinor =
+  zipToIntervalSet
   [Perfect, Major, Minor, Perfect, Perfect, Major, Major] [1..7]
-scaleToIntervals SDorianb2 =
-  nthDegreeIntervals (scaleToIntervals SMelodicMinor) 2
-scaleToIntervals SLydianAug =
-  nthDegreeIntervals (scaleToIntervals SMelodicMinor) 3
-scaleToIntervals SLydianDom =
-  nthDegreeIntervals (scaleToIntervals SMelodicMinor) 4
-scaleToIntervals SMixolydianb6 =
-  nthDegreeIntervals (scaleToIntervals SMelodicMinor) 5
-scaleToIntervals SLocrianSharp2 =
-  nthDegreeIntervals (scaleToIntervals SMelodicMinor) 6
-scaleToIntervals SAltered =
-  nthDegreeIntervals (scaleToIntervals SMelodicMinor) 7
-scaleToIntervals SHarmonicMinor =
-  listIntervals
+baseModeIntervals LydianAug =
+  nthDegreeIntervals (baseModeIntervals MelodicMinor) 3
+baseModeIntervals LydianDom =
+  nthDegreeIntervals (baseModeIntervals MelodicMinor) 4
+baseModeIntervals Altered =
+  nthDegreeIntervals (baseModeIntervals MelodicMinor) 7
+baseModeIntervals HarmonicMinor =
+  zipToIntervalSet
   [Perfect, Major, Minor, Perfect, Perfect, Minor, Major] [1..7]
-scaleToIntervals SLocrianNat6 =
-  nthDegreeIntervals (scaleToIntervals SHarmonicMinor) 2
-scaleToIntervals SIonianSharp5 =
-  nthDegreeIntervals (scaleToIntervals SHarmonicMinor) 3
-scaleToIntervals SDorianSharp4 =
-  nthDegreeIntervals (scaleToIntervals SHarmonicMinor) 4
-scaleToIntervals SPhrygianDom =
-  nthDegreeIntervals (scaleToIntervals SHarmonicMinor) 5
-scaleToIntervals SLydianSharp2 =
-  nthDegreeIntervals (scaleToIntervals SHarmonicMinor) 6
-scaleToIntervals SSuperLocrianbb7 =
-  nthDegreeIntervals (scaleToIntervals SHarmonicMinor) 7
+baseModeIntervals PhrygianDom =
+  nthDegreeIntervals (baseModeIntervals HarmonicMinor) 5
+baseModeIntervals DoubleHarmonicMinor =
+  zipToIntervalSet
+  [Perfect, Major, Minor, Augmented 1, Perfect, Minor, Major] [1..7]
+baseModeIntervals HarmonicMajor =
+  zipToIntervalSet
+  [Perfect, Major, Major, Perfect, Perfect, Minor, Major] [1..7]
+baseModeIntervals DoubleHarmonicMajor =
+  zipToIntervalSet
+  [Perfect, Minor, Major, Perfect, Perfect, Minor, Major] [1..7]
+
+
+-- modeToIntervals :: Mode -> Set Interval
+-- modeToIntervals baseMode exts = 
+--   where 
+--     baseIntervals = baseModeIntervals baseMode
+--     extIntervals :: [Extension] -> Set Interval -> Set Interval 
+--     <+>
+     

--- a/src/Scale.hs
+++ b/src/Scale.hs
@@ -171,9 +171,9 @@ modesToExts mode1 mode2 =
 intervalsToMode :: Set Interval -> [Mode]
 intervalsToMode intSet = 
   let 
-    sameDegreeModes = filter (\a -> S.map getSize (baseModeIntervals a) 
-                                 == S.map getSize intSet) 
-                      [Lydian ..]
+    sameDegreeModes =
+        filter (\bm -> ((==) `on` S.map getSize) (baseModeIntervals bm) intSet)
+               [Lydian ..]
     distanceFromIntSet :: Set Interval -> BaseMode -> Int
     distanceFromIntSet iSet mode = modalDistance iSet $ baseModeIntervals mode
     sortedModes = sortBy (compare `on` distanceFromIntSet intSet) sameDegreeModes

--- a/src/Scale.hs
+++ b/src/Scale.hs
@@ -41,7 +41,7 @@ instance Show Mode where
                        --Add a space if there are extensions...
                        ++ if null exts then "" else " "
                        --Add extensions separated by a comma...
-                       ++ (intercalate ", " (show <$> exts))        
+                       ++ intercalate ", " (show <$> exts)
 
 data ScaleExt = ScaleExt { acc :: Accidental
                          , deg :: Int


### PR DESCRIPTION
## Changes
- Added shiftToAcc function to go from an implied shift to an accidental
- Fixed default chord to be (1,3,5), i.e. no 7
- Added ScaleExt, BaseMode, Mode, and Scale datatypes. Also added functions to go from BaseMode/Mode to intervals, and Scale to notes.
- Added function to go from intervals to possible modes

## Issues / Need Help With
- ScaleExt seems to be very similar to the existing Extension -- can we abstract?
- Need helpful error messages when constructing a mode that doesn't make sense
- modesToExts just *feels* badly written
