### PR TITLE
Interval improvements

### DIFF
--- a/src/Base/Core/Accidental.hs
+++ b/src/Base/Core/Accidental.hs
@@ -33,7 +33,7 @@ impliedShift (AccFlat i)  = -i
 impliedShift AccNatural   = 0
 
 shiftToAcc :: Int -> Accidental
-shiftToAcc i = 
+shiftToAcc i
   | i > 0     = AccSharp i
   | i < 0     = AccFlat (-i)
   | otherwise = AccNatural

--- a/src/Base/Interval.hs
+++ b/src/Base/Interval.hs
@@ -170,5 +170,5 @@ jumpIntervalFromNote (Interval iQual iNum) r =
       case intervalToDistance $ Interval iQual iNum of
         Just dist -> dist
         Nothing -> error "Invalid interval in jumpIntervalFromNote"
-    newAcc     = shiftToAcc $ lowestAbsValue $ wantedDist - currDist  
+    newAcc     = shiftToAcc $ lowestAbsValue $ wantedDist - currDist
   in rootFrom newNote newAcc

--- a/src/Base/Interval.hs
+++ b/src/Base/Interval.hs
@@ -82,9 +82,12 @@ intervalToDistance interval =
 
     -- Diminished shifts
     Interval (Diminished x) i ->
-      case baseQuality i of
-        Major   -> subtract (x + 1) <$> intervalToDistance (Interval Major i)
-        Perfect -> subtract x <$> intervalToDistance (Interval Perfect i)
+      subtract offset <$> intervalToDistance (Interval bq i)
+      where
+        bq = baseQuality i
+        offset = case bq of
+                   Major   -> x + 1
+                   Perfect -> x
 
     -- Anything else must be an invalid interval
     _ -> Nothing
@@ -109,7 +112,7 @@ invert (Interval iQual i) =
 
 infixl 6 <+>
 (<+>) :: Interval -> Int -> Interval
-(Interval iQual i) <+> x =
+Interval iQual i <+> x =
   Interval (iterate modFunc iQual !! abs x) i
   where
     modFunc =

--- a/src/Base/Interval.hs
+++ b/src/Base/Interval.hs
@@ -52,9 +52,24 @@ instance Show Interval where
 normalizeIntervalSize :: Int -> Int
 normalizeIntervalSize = modByFrom 7 1
 
--- This smart constructor normalizes the interval size to be between 1 and 7
-intervalFrom :: Quality -> Int -> Interval
-intervalFrom q s = Interval { getQuality = q, getSize = normalizeIntervalSize s }
+-- TODO: This should probably return an Either String Interval (or an error
+-- type in place of String) instead of Maybe Interval, in order to facilitate
+-- more sophisticated error handling / reporting.
+intervalFrom :: Quality -> Int -> Maybe Interval
+intervalFrom q s = if normalizedSize `elem` goodSizes then
+                     Just Interval { getQuality = q, getSize = normalizedSize }
+                   else
+                     Nothing
+  where
+    normalizedSize :: Int
+    normalizedSize = normalizeIntervalSize s
+
+    goodSizes :: [Int]
+    goodSizes = case q of
+                  Perfect -> [1, 4, 5]
+                  Major   -> [2, 3, 6, 7]
+                  Minor   -> [2, 3, 6, 7]
+                  _       -> [1 .. 7]
 
 normalizeInterval :: Interval -> Interval
 normalizeInterval (Interval iQual i) = Interval iQual $ normalizeIntervalSize i

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -31,28 +31,28 @@ import Data.Map.Strict (Map, insert, fromList, toList, (!), delete, (!?))
 import Data.Maybe (fromJust)
 
 
-chordToNotes :: Chord -> Maybe [Root]
+chordToNotes :: Chord -> [Root]
 chordToNotes chord =
-  do chordInts <- chordToIntervals chord
-     return $ flip jumpIntervalFromNote (getChordRoot chord) <$> S.toList chordInts
+  flip jumpIntervalFromNote (getChordRoot chord) <$> S.toList (chordToIntervals chord)
 
 
-chordToIntervals :: Chord -> Maybe (Set Interval)
+chordToIntervals :: Chord -> Set Interval
 chordToIntervals chord =
-  do qualInts <- qualityToIntervals $ C.getQuality chord
-     baseScale <- highestNaturalToIntervals (getHighestNatural chord) qualInts
-     extendedScale <- extendIntervals baseScale $ getExtensions chord
-     intervals <- susIntervals extendedScale $ getSus chord
-     return $ foldr S.insert S.empty intervals
+  let
+    qualInts  = qualityToIntervals $ C.getQuality chord
+    baseScale = highestNaturalToIntervals (getHighestNatural chord) qualInts
+    extendedScale = extendIntervals baseScale $ getExtensions chord
+    intervals     = susIntervals extendedScale $ getSus chord
+  in
+    foldr S.insert S.empty intervals
 
 
 type HeliotonicScale = Map Int Interval
 
 
-qualityToIntervals :: CQ.Quality -> Maybe HeliotonicScale
+qualityToIntervals :: CQ.Quality -> HeliotonicScale
 qualityToIntervals qual =
-  do bmInts <- baseModeIntervals $ qualityToScale qual
-     return $ fromList $ zip [1 .. 7] $ S.toList bmInts
+  fromList $ zip [1 .. 7] $ S.toList $ baseModeIntervals $ qualityToScale qual
   where
     qualityToScale :: CQ.Quality -> BaseMode
     qualityToScale CQ.Major = Lydian
@@ -62,27 +62,26 @@ qualityToIntervals qual =
     qualityToScale CQ.Diminished = DiminishedQuality
 
 
-susIntervals :: HeliotonicScale -> Sus -> Maybe HeliotonicScale
-susIntervals scale s = maybe (return scale) addSus (getMaybeDeg s)
+susIntervals :: HeliotonicScale -> Sus -> HeliotonicScale
+susIntervals scale s = maybe scale addSus (getMaybeDeg s)
   where
-    addSus :: Int -> Maybe HeliotonicScale
-    addSus i = do int <- intervalFrom (baseQuality i) i
-                  return $ insert i int $ delete 3 scale
+    -- intervalFrom (baseQuality i) i is always a valid interval
+    addSus :: Int -> HeliotonicScale
+    addSus i =
+      insert i (fromJust $ intervalFrom (baseQuality i) i) $ delete 3 scale
 
 
-extendIntervals :: HeliotonicScale -> [Extension] -> Maybe HeliotonicScale
-extendIntervals = foldM extendInterval
+extendIntervals :: HeliotonicScale -> [Extension] -> HeliotonicScale
+extendIntervals = foldr $ flip extendInterval
   where
-  extendInterval :: HeliotonicScale -> Extension -> Maybe HeliotonicScale
+  extendInterval :: HeliotonicScale -> Extension -> HeliotonicScale
   extendInterval scale ext =
-    do int <- intervalFrom (baseQuality deg) deg
-       return $ insert deg (int <+> shift) scale
-    -- insert deg (intervalFrom (baseQuality deg) deg <+> shift) scale
+    insert deg (fromJust (intervalFrom (baseQuality deg) deg) <+> shift) scale
     where
       deg   = degree ext
       shift = sign ext
 
-highestNaturalToIntervals :: HighestNatural -> HeliotonicScale -> Maybe HeliotonicScale
+highestNaturalToIntervals :: HighestNatural -> HeliotonicScale -> HeliotonicScale
 highestNaturalToIntervals hn scale =
   let
     scaleInts = getIntervals subset scale
@@ -90,7 +89,7 @@ highestNaturalToIntervals hn scale =
     if isMajor hn then
       insertMajorSeven scaleInts
     else
-      return scaleInts
+      scaleInts
   where
     subset =
       let
@@ -111,7 +110,5 @@ highestNaturalToIntervals hn scale =
       in
         (int, fromJust interval)
 
-    insertMajorSeven :: HeliotonicScale -> Maybe HeliotonicScale
-    insertMajorSeven hts =
-      do int <- intervalFrom IQ.Major 7
-         return $ insert 7 int hts
+    insertMajorSeven :: HeliotonicScale -> HeliotonicScale
+    insertMajorSeven hts = insert 7 (fromJust $ intervalFrom IQ.Major 7) hts

--- a/src/Scale.hs
+++ b/src/Scale.hs
@@ -21,6 +21,7 @@ import Base.Chord.Root
 import Base.Interval hiding (invert)
 import qualified Base.Interval as I (invert)
 import Base.Core.Accidental(Accidental(..), impliedShift, shiftToAcc, natural)
+import Control.Monad (filterM, zipWithM)
 import Data.List (sort, sortBy, intercalate, takeWhile)
 import Data.Set(Set(..), fromList, toAscList, elemAt, insert, delete, mapMonotonic, isSubsetOf)
 import qualified Data.Set as S(filter, map)
@@ -51,7 +52,7 @@ instance Show ScaleExt where
   show ext = show (acc ext) ++ show (deg ext)
 
 
-data BaseMode 
+data BaseMode
   = Lydian
   | Dorian
   | Mixolydian
@@ -70,126 +71,160 @@ data BaseMode
   | DoubleHarmonicMinor
   | HarmonicMajor
   | DoubleHarmonicMajor
-  deriving (Show, Enum)
+  deriving (Show, Enum, Eq)
 
 
-nthDegreeIntervals :: Set Interval -> Int -> Set Interval
-nthDegreeIntervals ints n = S.map (|-| rootInterval) ints
+nthDegreeIntervals :: Set Interval -> Int -> Maybe (Set Interval)
+nthDegreeIntervals ints n = return $ S.map (|-| rootInterval) ints
   where
     rootInterval = toAscList ints !! (n - 1)
 
 
-zipToIntervalSet :: [Quality] -> [Int] -> Set Interval
-zipToIntervalSet qualities ints = fromList $ uncurry intervalFrom <$> zip qualities ints
+zipToIntervalSet :: [Quality] -> [Int] -> Maybe (Set Interval)
+zipToIntervalSet quals sizes =
+  do ints <- zipWithM intervalFrom quals sizes
+     return $ fromList ints
 
 
-baseModeIntervals :: BaseMode -> Set Interval
-baseModeIntervals Ionian =
-  zipToIntervalSet
-  [Perfect, Major, Major, Perfect, Perfect, Major, Major] [1..7]
-baseModeIntervals Dorian =
-  nthDegreeIntervals (baseModeIntervals Ionian) 2
-baseModeIntervals Phrygian =
-  nthDegreeIntervals (baseModeIntervals Ionian) 3
-baseModeIntervals Lydian =
-  nthDegreeIntervals (baseModeIntervals Ionian) 4
-baseModeIntervals Mixolydian =
-  nthDegreeIntervals (baseModeIntervals Ionian) 5
-baseModeIntervals Aeolian =
-  nthDegreeIntervals (baseModeIntervals Ionian) 6
-baseModeIntervals Locrian =
-  nthDegreeIntervals (baseModeIntervals Ionian) 7
-baseModeIntervals AugmentedQuality =
-  zipToIntervalSet
-  [Perfect, Major, Major, Augmented 1, Augmented 1, Major, Minor] [1..7]
-baseModeIntervals DiminishedQuality =
-  zipToIntervalSet
-  [Perfect, Major, Minor, Perfect, Diminished 1, Minor, Diminished 1] [1..7]
-baseModeIntervals MelodicMinor =
-  zipToIntervalSet
-  [Perfect, Major, Minor, Perfect, Perfect, Major, Major] [1..7]
-baseModeIntervals LydianAug =
-  nthDegreeIntervals (baseModeIntervals MelodicMinor) 3
-baseModeIntervals LydianDom =
-  nthDegreeIntervals (baseModeIntervals MelodicMinor) 4
-baseModeIntervals Altered =
-  nthDegreeIntervals (baseModeIntervals MelodicMinor) 7
-baseModeIntervals HarmonicMinor =
-  zipToIntervalSet
-  [Perfect, Major, Minor, Perfect, Perfect, Minor, Major] [1..7]
-baseModeIntervals PhrygianDom =
-  nthDegreeIntervals (baseModeIntervals HarmonicMinor) 5
-baseModeIntervals DoubleHarmonicMinor =
-  zipToIntervalSet
-  [Perfect, Major, Minor, Augmented 1, Perfect, Minor, Major] [1..7]
-baseModeIntervals HarmonicMajor =
-  zipToIntervalSet
-  [Perfect, Major, Major, Perfect, Perfect, Minor, Major] [1..7]
-baseModeIntervals DoubleHarmonicMajor =
-  zipToIntervalSet
-  [Perfect, Minor, Major, Perfect, Perfect, Minor, Major] [1..7]
+baseModeIntervals :: BaseMode -> Maybe (Set Interval)
+baseModeIntervals bm = if fromScratch then
+                         zipToIntervalSet bmQualities [1 .. 7]
+                       else
+                         do let (mode, shift) = modeAndShift
+                            ints <- baseModeIntervals mode
+                            nthDegreeIntervals ints shift
+  where
+    -- Discriminate between BaseModes for which we build the intervals from
+    -- scratch and those that are computed from some other interval set
+    fromScratch :: Bool
+    fromScratch = bm `elem` [ Ionian
+                            , AugmentedQuality
+                            , DiminishedQuality
+                            , MelodicMinor
+                            , HarmonicMinor
+                            , DoubleHarmonicMinor
+                            , HarmonicMajor
+                            , DoubleHarmonicMajor
+                            ]
+
+    -- The interval qualities for the modal interval sets built from scratch
+    bmQualities :: [Quality]
+    bmQualities =
+      case bm of
+        Ionian ->
+          [Perfect, Major, Major, Perfect, Perfect, Major, Major]
+        AugmentedQuality ->
+          [Perfect, Major, Major, Augmented 1, Augmented 1, Major, Minor]
+        DiminishedQuality ->
+          [Perfect, Major, Minor, Perfect, Diminished 1, Minor, Diminished 1]
+        MelodicMinor ->
+          [Perfect, Major, Minor, Perfect, Perfect, Major, Major]
+        HarmonicMinor ->
+          [Perfect, Major, Minor, Perfect, Perfect, Minor, Major]
+        DoubleHarmonicMinor ->
+          [Perfect, Major, Minor, Augmented 1, Perfect, Minor, Major]
+        HarmonicMajor ->
+          [Perfect, Major, Major, Perfect, Perfect, Minor, Major]
+        DoubleHarmonicMajor ->
+          [Perfect, Minor, Major, Perfect, Perfect, Minor, Major]
+
+    -- The starting mode and shift for modal interval sets built from other
+    -- interval sets
+    modeAndShift :: (BaseMode, Int)
+    modeAndShift =
+      case bm of
+        Dorian      -> (Ionian, 2)
+        Phrygian    -> (Ionian, 3)
+        Lydian      -> (Ionian, 4)
+        Mixolydian  -> (Ionian, 5)
+        Aeolian     -> (Ionian, 6)
+        Locrian     -> (Ionian, 7)
+        LydianAug   -> (MelodicMinor, 3)
+        LydianDom   -> (MelodicMinor, 4)
+        Altered     -> (MelodicMinor, 7)
+        PhrygianDom -> (HarmonicMinor, 5)
 
 
-modeToIntervals :: Mode -> Set Interval
-modeToIntervals (Mode baseMode exts) = foldr extIntervals (baseModeIntervals baseMode) exts
-  where 
+modeToIntervals :: Mode -> Maybe (Set Interval)
+modeToIntervals (Mode baseMode exts) =
+  do bmInts <- baseModeIntervals baseMode
+     return $ foldr extIntervals bmInts exts
+  where
     extIntervals :: ScaleExt -> Set Interval -> Set Interval
-    extIntervals ext intSet = insert (oldInt <+> (impliedShift $ acc ext)) (delete oldInt intSet)
+    extIntervals ext intSet = insert (oldInt <+> impliedShift (acc ext)) (delete oldInt intSet)
       where
         -- TODO: If there isn't only one interval of a certain degree, the mode is
         -- ambiguously constructed and we should give a warning.
-        oldInt = elemAt 0 (S.filter (\a -> getSize a == deg ext) intSet)    
+        oldInt = elemAt 0 (S.filter (\a -> getSize a == deg ext) intSet)
 
 
-scaleToNotes :: Scale -> Set Root
-scaleToNotes (Scale root mode) = mapMonotonic (`jumpIntervalFromNote` root) (modeToIntervals mode)
+scaleToNotes :: Scale -> Maybe (Set Root)
+scaleToNotes (Scale root mode) =
+  do modeInts <- modeToIntervals mode
+     return $ mapMonotonic (`jumpIntervalFromNote` root) modeInts
 
 
 modalDistance :: Set Interval -> Set Interval -> Int
 modalDistance mode1 mode2 = sum $ intDistance <$> (zip `on` toAscList) mode1 mode2
-  where 
+  where
     intDistance :: (Interval, Interval) -> Int
-    intDistance (i1, i2) = abs $ fromJust $ intervalToDistance (i1 |-| i2) 
+    intDistance (i1, i2) = abs $ fromJust $ intervalToDistance (i1 |-| i2)
 
 
 modesToExts :: Set Interval -> Set Interval -> [ScaleExt]
-modesToExts mode1 mode2 = 
-  let 
-    zippedInts = zip (toAscList mode1) (toAscList mode2)  
+modesToExts mode1 mode2 =
+  let
+    zippedInts = zip (toAscList mode1) (toAscList mode2)
     intervalDiffToAcc :: Interval -> Interval -> Accidental
     intervalDiffToAcc i1 i2 = shiftToAcc $ fromJust $ intervalToDistance $ i2 |-| i1
     accToExtList :: Accidental -> Int -> [ScaleExt] -> [ScaleExt]
     accToExtList accidental degree
       | accidental == natural = id
       | otherwise             = (ScaleExt { acc = accidental, deg = degree } :)
-  in  
-    foldr (\(i1,i2) exts -> accToExtList (intervalDiffToAcc i2 i1) (getSize i1) exts) 
-          []
-          zippedInts 
-
-
-intervalsToMode :: Set Interval -> [Mode]
-intervalsToMode intSet = 
-  let 
-    sameDegreeModes =
-        filter (\bm -> ((==) `on` S.map getSize) (baseModeIntervals bm) intSet)
-               [Lydian ..]
-    distanceFromIntSet :: Set Interval -> BaseMode -> Int
-    distanceFromIntSet iSet mode = modalDistance iSet $ baseModeIntervals mode
-    sortedModes = sortBy (compare `on` distanceFromIntSet intSet) sameDegreeModes
-    exts = modesToExts intSet . baseModeIntervals <$> sortedModes
   in
-    takeWhile (\mode -> numAlteredDegsInMode mode == minimum (length <$> exts)) $ (\(x,y) -> Mode x y) <$> zip sortedModes exts
+    foldr (\(i1,i2) exts -> accToExtList (intervalDiffToAcc i2 i1) (getSize i1) exts)
+          []
+          zippedInts
+
+
+intervalsToMode :: Set Interval -> Maybe [Mode]
+intervalsToMode intSet =
+  let
+    eqOnSize :: BaseMode -> Maybe Bool
+    eqOnSize bm =
+      do bmInts <- baseModeIntervals bm
+         return $ ((==) `on` S.map getSize) bmInts intSet
+
+    mSameDegreeModes :: Maybe [BaseMode]
+    mSameDegreeModes = filterM eqOnSize [Lydian ..]
+
+    distanceFromIntSet :: Set Interval -> BaseMode -> Maybe Int
+    distanceFromIntSet iSet mode =
+      do bmInts <- baseModeIntervals mode
+         return $ modalDistance iSet bmInts
+
+    mSortedModes :: Maybe [BaseMode]
+    mSortedModes = sortBy (compare `on` distanceFromIntSet intSet) <$> mSameDegreeModes
+
+    mExts :: Maybe [[ScaleExt]]
+    mExts =
+      do sortedModes <- mSortedModes
+         bmIntss <- sequence $ baseModeIntervals <$> sortedModes
+         return $ modesToExts intSet <$> bmIntss
+  in
+    do sortedModes <- mSortedModes
+       exts <- mExts
+       return $ takeWhile (\mode -> numAlteredDegsInMode mode == minimum (length <$> exts)) $ uncurry Mode <$> zip sortedModes exts
 
 
 isSubsetMode :: Set Interval -> Set Interval -> Bool
-isSubsetMode mode1 mode2 = isSubsetOf mode1 mode2 
+isSubsetMode = isSubsetOf
 
 getSubsetModeByDegree :: Set Interval -> Set Int -> Set Interval
-getSubsetModeByDegree mode degs = S.filter (\i -> any (== getSize i) degs) mode
+getSubsetModeByDegree mode degs = S.filter (\i -> getSize i `elem` degs) mode
 
 invert :: Set Interval -> Set Interval
-invert mode = S.map I.invert mode
+invert = S.map I.invert
 
-numAlteredDegsInMode :: Mode -> Int 
+numAlteredDegsInMode :: Mode -> Int
 numAlteredDegsInMode (Mode base exts) = length exts


### PR DESCRIPTION
At long last, I've made the `Interval` module a bit more robust by implementing a smart constructor that may fail.

Note that the individual commits in this PR will not build, since this change required propagation to both `Scale` and `Lib`, but the final commit _does_ build and run as expected.

I would love an extra pair of eyes to confirm that the changes I made didn't break the music-theoretical concepts at all; I'm fairly certain everything is still correct, but @edwisdom, you should make sure that's actually true before we get this merged in.

### Changes

#### Base.Accidental

There was a small typo here that prevented the build from passing; I think #17  also implements this fix, but that's not a problem.

#### Base.Interval

The `intervalFrom` function has been replaced so that it has type `Quality -> Int -> Maybe Interval`. The function now checks that the provided `Quality` and `Int` actually make sense together, returning `Nothing` when they don't. This change demanded changes throughout a significant amount of code, but the change was essentially "do what we were doing before, but in the `Maybe` monad."

#### Lib / Scale

There's a bunch of changes here, but as I said above, they're essentially only meaningful in that they lift what we were doing before into the `Maybe` monad to account for the fact that operations may now fail when trying to construct intervals that aren't valid. I'm not going to detail all of the changes here; I'll pick a sufficiently interesting one and put some inline review comments explaining what's going on.

